### PR TITLE
improve system information (CPU, GPU)

### DIFF
--- a/ESCA/main.cpp
+++ b/ESCA/main.cpp
@@ -55,7 +55,6 @@ int main(int argc, char *argv[])
     const QUrl url(QStringLiteral("qrc:/qml/main.qml"));
 
     engine.rootContext()->setContextProperty("RecordingObject", &recordingController);
-    engine.rootContext()->setContextProperty("BackendObject", &systemInformationController);
     engine.rootContext()->setContextProperty("AIObject", &aiController);
     engine.rootContext()->setContextProperty("TransferObject", &transferController);
 
@@ -65,6 +64,7 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("NotificationLoggerCpp", &notificationLogger);
 
     qmlRegisterType<FileIO>("FileIO", 1, 0, "FileIO");
+    qmlRegisterType<SystemInformationController>("SystemInformation", 1, 0, "SystemInformationController");
 
     QObject::connect(
         &engine,

--- a/ESCA/qml/content/SystemInformation/realTimeMonitor.qml
+++ b/ESCA/qml/content/SystemInformation/realTimeMonitor.qml
@@ -1,13 +1,17 @@
 import QtQuick 2.15
-import QtQuick.Controls 2.15
-
+import QtQuick.Controls 2.1
 import "../component"
+import SystemInformation 1.0
 
 Rectangle {
     id: rectangle
     width: 1024
     height: 480
     color: "#2a2a2a"
+
+    SystemInformationController {
+        id: backendObject
+    }
 
     // graph
     CpuFrame{
@@ -69,7 +73,7 @@ Rectangle {
         width: 313
         height: 40
         color: "#ffffff"
-        text: BackendObject.diskText
+        text: backendObject.diskText
         font.pixelSize: 23
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter

--- a/ESCA/qml/content/SystemInformation/systemInformation.qml
+++ b/ESCA/qml/content/SystemInformation/systemInformation.qml
@@ -1,13 +1,15 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import "../component"
+import SystemInformation 1.0
 
 Rectangle {
     width: 1000
     height: 420
     color: "#2a2a2a"
-
-    // TEMP COMPONENT
+    SystemInformationController {
+        id: backendObject
+    }
 
     Text {
         id: diskUsage
@@ -16,7 +18,7 @@ Rectangle {
         width: 272
         height: 40
         color: "#ffffff"
-        text: BackendObject.diskText
+        text: backendObject.diskText
         font.pixelSize: 20
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter
@@ -79,7 +81,7 @@ Rectangle {
         width: 663
         height: 40
         color: "#ffffff"
-        text: "CPU: Quad-core ARM Cortex-A57 MPCore processor"
+        text: "CPU" + backendObject.getCpuName()
         font.pixelSize: 20
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter
@@ -95,7 +97,7 @@ Rectangle {
         width: 663
         height: 40
         color: "#ffffff"
-        text: "GPU: NVIDIA Maxwell architecture with 128 NVIDIA CUDA® cores\t"
+        text: "GPU:" + backendObject.getGpuName()
         font.pixelSize: 20
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter
@@ -182,13 +184,13 @@ Rectangle {
     }
 
     Text {
-        id: internetStatus5
+        id: cacheL1
         x: 758
         y: 86
         width: 140
         height: 40
         color: "#ffffff"
-        text: "L1:      32 KB"
+        text: "L1:      " + backendObject.getCacheL1() + " KB"
         font.pixelSize: 20
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter
@@ -198,13 +200,13 @@ Rectangle {
     }
 
     Text {
-        id: internetStatus6
+        id: cacheL2
         x: 758
         y: 147
         width: 140
         height: 40
         color: "#ffffff"
-        text: "L2:      2 MB"
+        text: "L2:      " + backendObject.getCacheL2() + "B"
         font.pixelSize: 20
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter

--- a/ESCA/qml/content/component/CpuFrame.qml
+++ b/ESCA/qml/content/component/CpuFrame.qml
@@ -52,13 +52,13 @@ Item {
         y: 73
         width: 176
         height: 121
-        _45Text: BackendObject.cpuText
+        _45Text: backendObject.cpuText
         minutesRemainingText: "CPU Usage"
     }
 
     RangeMapper {
         id: rangeMapper
-        input: BackendObject.cpuPercentage
+        input: backendObject.cpuPercentage
         outputMaximum: 180
         outputMinimum: -180
     }

--- a/ESCA/qml/content/component/GpuFrame.qml
+++ b/ESCA/qml/content/component/GpuFrame.qml
@@ -52,13 +52,13 @@ Item {
         y: 73
         width: 176
         height: 121
-        _45Text: BackendObject.cpuText
+        _45Text: backendObject.gpuText
         minutesRemainingText: "GPU Usage"
     }
 
     RangeMapper {
         id: rangeMapper
-        input: BackendObject.cpuPercentage
+        input: backendObject.gpuPercentage
         outputMaximum: 180
         outputMinimum: -180
     }

--- a/ESCA/qml/content/component/RamFrame.qml
+++ b/ESCA/qml/content/component/RamFrame.qml
@@ -52,13 +52,13 @@ Item {
         y: 73
         width: 176
         height: 121
-        _45Text: BackendObject.ramText
+        _45Text: backendObject.ramText
         minutesRemainingText: "RAM Usage"
     }
 
     RangeMapper {
         id: rangeMapper
-        input: BackendObject.ramPercentage
+        input: backendObject.ramPercentage
         outputMaximum: 180
         outputMinimum: -180
     }

--- a/ESCA/src/modules/systeminformation/systeminformationcontroller.cpp
+++ b/ESCA/src/modules/systeminformation/systeminformationcontroller.cpp
@@ -1,28 +1,38 @@
 #include "systeminformationcontroller.h"
 #include <QDebug>
+#include <QProcess>
 
 SystemInformationController::SystemInformationController(QObject *parent) : QObject{parent} {
+    qDebug() << "Instance created";
     m_timer.setInterval(3);
     m_timer.setSingleShot(false);
     m_timer.start(1000);
     connect(&m_timer, &QTimer::timeout, this, [this]() {
 
         // For cpu
-        cpu_usage = getCpu();
+        m_cpu = getCpu();
+
+        // For gpu
+        m_gpu = getGpu();
 
         // For ram
-        ram_usage = getRam();
+        m_ram = getRam();
 
         // For disk
-        disk_usage = getDisk();
+        m_disk = getDisk();
 
         // Both
         emit cpuChanged();
+        emit gpuChanged();
         emit ramChanged();
         emit diskChanged();
     });
 }
 
+SystemInformationController::~SystemInformationController() {
+    m_timer.stop();
+    qDebug() << "Instance destroyed";
+}
 
 double SystemInformationController::getDisk() {
     QStorageInfo storage = QStorageInfo::root();
@@ -61,6 +71,7 @@ double SystemInformationController::getRam(){
     return static_cast<double>(memTotal-memFree)/memTotal * 100;
 }
 
+//CPU
 double SystemInformationController::getCpu()
 {
     double percent;
@@ -75,7 +86,7 @@ double SystemInformationController::getCpu()
     if (totalUser < lastTotalUser || totalUserLow < lastTotalUserLow ||
         totalSys < lastTotalSys || totalIdle < lastTotalIdle){
         //Overflow detection. Just skip this value.
-        percent = -1.0;
+        percent = 0;
     }
     else{
         total = (totalUser - lastTotalUser) + (totalUserLow - lastTotalUserLow) +
@@ -93,21 +104,127 @@ double SystemInformationController::getCpu()
 
     return percent;
 }
-// end
 
+QString SystemInformationController::getCpuName() {
+    FILE* file = fopen("/proc/cpuinfo", "r");
+    char line[128];
 
-int SystemInformationController::cpuPercentage() const { return cpu_usage; }
-
-QString SystemInformationController::cpuText() const {
-    return QString::number(cpu_usage) + "%";
+    while (fgets(line, 128, file) != NULL){
+        if (strncmp(line, "model name", 10) == 0){
+            char* p = line;
+            while(*p != ':') {
+                p++;
+            }
+            return QString::fromUtf8(p).trimmed();
+        }
+    }
+    fclose(file);
+    return "Unknown CPU";
 }
 
-int SystemInformationController::ramPercentage() const { return ram_usage; }
+//GPU
+int SystemInformationController::getGpu() {
+    QProcess process;
+
+    process.start("nvidia-smi", QStringList() << "--query-gpu=memory.total,memory.used --format=csv,noheader");
+    if(!process.waitForFinished()) {
+        qDebug() << "Error: " << process.errorString();
+        return -1;
+    }
+    QString gpuMemory = process.readAll();
+    QStringList parts = gpuMemory.split(", ", Qt::SkipEmptyParts);
+
+    QString totalGpu = parts[0].split(" ")[0];
+    QString usedGpu = parts[1].split(" ")[0];
+
+    return (usedGpu.toInt() * 100) / totalGpu.toInt();
+}
+
+QString SystemInformationController::getGpuName() {
+    QProcess process;
+
+    process.start("nvidia-smi", QStringList() << "--query-gpu=name --format=csv,noheader");
+    if(!process.waitForFinished()) {
+        qDebug() << "Error: " << process.errorString();
+        return "Unknown GPU";
+    }
+
+    QString gpuName = process.readAll();
+
+    return gpuName;
+}
+
+//Function to get cache
+int SystemInformationController::getCacheL1() {
+    QProcess process;
+    int L1i_cache = 0;
+    int L1d_cache = 0;
+    int L1_cache = 0;
+
+    process.start("lscpu", QStringList() << "-C");
+    if(!process.waitForFinished()) {
+        qDebug() << "Error: " << process.errorString();
+    }
+
+    QString output = process.readAll();
+    QStringList lines = output.split("\n");
+
+    for (int i = 0; i < lines.size(); i++) {
+        const QString &line = lines.at(i);
+        if (line.startsWith("L1d")) {
+            QStringList parts = line.split(" ", Qt::SkipEmptyParts);
+            QStringList L1d = parts[2].split("K");
+            L1d_cache = L1d[0].toInt();
+        }
+        if (line.startsWith("L1i")) {
+            QStringList parts = line.split(" ", Qt::SkipEmptyParts);
+            QStringList L1i = parts[2].split("K");
+            L1i_cache = L1i[0].toInt();
+        }
+        L1_cache = L1d_cache + L1i_cache;
+    }
+    return L1_cache;
+}
+
+QString SystemInformationController::getCacheL2() {
+    QProcess process;
+
+    process.start("lscpu", QStringList() << "-C");
+    if(!process.waitForFinished()) {
+        qDebug() << "Error: " << process.errorString();
+    }
+
+    QString output = process.readAll();
+    QStringList lines = output.split("\n");
+
+    for (int i = 0; i < lines.size(); i++) {
+        const QString &line = lines.at(i);
+        if (line.startsWith("L2")) {
+            QStringList parts = line.split(" ", Qt::SkipEmptyParts);
+            return parts[2];
+        }
+    }
+    return "Unknow";
+}
+
+int SystemInformationController::cpuPercentage() const { return m_cpu; }
+
+QString SystemInformationController::cpuText() const {
+    return QString::number(m_cpu) + "%";
+}
+
+int SystemInformationController::gpuPercentage() const { return m_gpu; }
+
+QString SystemInformationController::gpuText() const {
+    return QString::number(m_gpu) + "%";
+}
+
+int SystemInformationController::ramPercentage() const { return m_ram; }
 
 QString SystemInformationController::ramText() const {
-    return QString::number(ram_usage) + "%";
+    return QString::number(m_ram) + "%";
 }
 
 QString SystemInformationController::diskText() const {
-    return "Disk usage: " + QString::number(disk_usage) + "%";
+    return "Disk usage: " + QString::number(m_disk) + "%";
 }

--- a/ESCA/src/modules/systeminformation/systeminformationcontroller.h
+++ b/ESCA/src/modules/systeminformation/systeminformationcontroller.h
@@ -1,8 +1,6 @@
 #ifndef SYSTEMINFORMATIONCONTROLLER_H
 #define SYSTEMINFORMATIONCONTROLLER_H
-
 #include <QObject>
-#include <tuple>
 #include <QQmlEngine>
 #include <QTimer>
 #include <QFile>
@@ -13,46 +11,58 @@ class SystemInformationController : public QObject
 {
 
     Q_OBJECT
-    
+
     Q_PROPERTY(int cpuPercentage READ cpuPercentage NOTIFY cpuChanged)
+    Q_PROPERTY(int gpuPercentage READ gpuPercentage NOTIFY gpuChanged)
     Q_PROPERTY(QString cpuText READ cpuText NOTIFY cpuChanged)
+    Q_PROPERTY(QString gpuText READ gpuText NOTIFY gpuChanged)
     Q_PROPERTY(int ramPercentage READ ramPercentage NOTIFY ramChanged)
     Q_PROPERTY(QString ramText READ ramText NOTIFY ramChanged)
     Q_PROPERTY(QString diskText READ diskText NOTIFY diskChanged)
 
 public:
     explicit SystemInformationController(QObject *parent = nullptr);
-
-signals:
-    void cpuChanged();
-    void ramChanged();
-    void diskChanged();
-
-private:
+    ~SystemInformationController();
     int cpuPercentage() const;
     QString cpuText() const;
+
+    int gpuPercentage() const;
+    QString gpuText() const;
 
     int ramPercentage() const;
     QString ramText() const;
 
     QString diskText() const;
 
+signals:
+    void cpuChanged();
+    void gpuChanged();
+    void ramChanged();
+    void diskChanged();
+
+public slots:
+    QString getCpuName();
+    QString getGpuName();
+    int getCacheL1();
+    QString getCacheL2();
+
+private:
     QTimer m_timer;
 
     unsigned long long lastTotalUser, lastTotalUserLow, lastTotalSys, lastTotalIdle;
-    int cpu_usage = 0;
-
-    int ram_usage = 0;
-
-    int disk_usage = 0;
-
-    unsigned int user, total = 0;
-    std::tuple<unsigned int, unsigned int> readFile();
-
+    unsigned int total = 0;
+    int m_cpu = 0;
     double getCpu();
-    double getRam();
+
+    int m_gpu = 0;
+    int getGpu();
+
     int parseLine(char* line);
+    int m_ram = 0;
+    double getRam();
+
+    int m_disk = 0;
     double getDisk();
 };
 
-#endif // SYSTEMINFORMATIONCONTROLLER_H
+#endif // SYSTEMRESOURCECONTROLLER_H


### PR DESCRIPTION
- Sử dụng qmlRegisterType để tạo và hủy instance trong QML.
- Lấy % sử dụng của GPU thông qua cmd nvidia-smi --query-gpu=memory.total,memory.used --format=csv,noheader
- Lây tên GPU thông qua cmd nvidia-smi --query-gpu=name --format=csv,noheader (noheader để bỏ dòng đầu - dòng tiêu đề các thông số)
- Lấy cache L1, L2 (L1 bao gồm L1d lưu trữ data và L1i lưu trữ instructions)